### PR TITLE
feat: preemptively guard AddProject tabs against unsaved project state

### DIFF
--- a/src/components/AddProject.tsx
+++ b/src/components/AddProject.tsx
@@ -109,7 +109,13 @@ const AddProject: React.FC<AddProjectProps> = ({ isSidebarOpen }) => {
 
   // Tab switching
   const [activeTab, setActiveTab] = useState('details')
-  const handleNavClick = (tab: string) => setActiveTab(tab)
+  const handleNavClick = (tab: string) => {
+    if (!isEdit && !projectId && tab !== 'details') {
+      notify('Please save your project before accessing this section.')
+      return
+    }
+    setActiveTab(tab)
+  }
 
   // LOAD objectives and project data if editing
   useEffect(() => {


### PR DESCRIPTION
This prevents future runtime errors when components like AddRisk expect a valid projectId. Adds UI guard to block tab switching until the project is saved.